### PR TITLE
Little fixes

### DIFF
--- a/include/RSS_Http.h
+++ b/include/RSS_Http.h
@@ -10,6 +10,7 @@
     */
 typedef struct RSS_Url {
     char*    host;
+    int      port;
     char*    path;
 } RSS_Url;
 

--- a/src/RSS_Html.c
+++ b/src/RSS_Html.c
@@ -116,6 +116,19 @@ RSS_char* RSS_html_decode(const RSS_char* str) {
     pos = 0;
 
     while(pos < length) {
+        // Trim start
+        if (temp->len == 0)
+        {
+            switch(str[pos]) {
+                case RSS_text('\r'):
+                case RSS_text('\n'):
+                case RSS_text('\t'):
+                case RSS_text(' '):
+                    pos++;
+                    continue;
+            }
+        }
+        
         if(str[pos] == RSS_text('&')) {
             if(pos + 2 < length && str[pos+1] == RSS_text('#')) {
                 /* &#x1A4F */
@@ -146,6 +159,13 @@ RSS_char* RSS_html_decode(const RSS_char* str) {
         }
     }
 
+    // Only whitespace characters in input
+    if (temp->len == 0)
+    {
+       RSS_free_buffer(temp);
+       return NULL;
+    }
+    
     res = RSS_strdup(temp->str);
     RSS_free_buffer(temp);
     return res;

--- a/src/RSS_Html.c
+++ b/src/RSS_Html.c
@@ -116,7 +116,7 @@ RSS_char* RSS_html_decode(const RSS_char* str) {
     pos = 0;
 
     while(pos < length) {
-        // Trim start
+        /* Trim start */
         if (temp->len == 0)
         {
             switch(str[pos]) {
@@ -159,7 +159,7 @@ RSS_char* RSS_html_decode(const RSS_char* str) {
         }
     }
 
-    // Only whitespace characters in input
+    /* Only whitespace characters in input */
     if (temp->len == 0)
     {
        RSS_free_buffer(temp);


### PR DESCRIPTION
1) Fixed skipping item nodes with whitespaces in inner text:
Example:

``` xml
<rss version="2.0">
   <channel>
      <title>...</title>...
      <item>
        !!!<title>...</title>...
      </item>
```

(! = space symbols)
2) Added custom port support for parse by url.
